### PR TITLE
Update magento/framework requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php": ">=7",
-        "magento/framework": "^100"
+        "magento/framework": "^100|^101"
     },
     "autoload": {
         "files": [ "registration.php" ],


### PR DESCRIPTION
Update magento/framework requirement in composer.json. This is to remove issues when upgrading magento to version 2.2.0. Example error displayed below: 

```
  Problem 1
    - Installation request for ampersand/fredhopper-m2 1.3.2 -> satisfiable by ampersand/fredhopper-m2[1.3.2].
    - Conclusion: remove magento/framework 101.0.0-rc23
    - Conclusion: don't install magento/framework 101.0.0-rc23
    - ampersand/fredhopper-m2 1.3.2 requires ampersand/category-code ^1.0 -> satisfiable by ampersand/category-code[v1.0.0, 1.1.0, 1.2.0].
    - ampersand/category-code 1.2.0 requires snowio/magento2-lock ^1.0.0 -> satisfiable by snowio/magento2-lock[v1.0.0, v1.1.0].
    - ampersand/category-code 1.2.0 requires snowio/magento2-lock ^1.0.0 -> satisfiable by snowio/magento2-lock[v1.0.0, v1.1.0].
    - snowio/magento2-lock v1.0.0 requires magento/framework ^100 -> satisfiable by magento/framework[100.0.2, 100.0.3, 100.0.4, 100.0.5, 100.0.6, 100.0.7, 100.0.8, 100.0.9, 100.1.0-rc1, 100.1.0-rc2, 100.1.0-rc3, 100.1.0, 100.0.10, 100.0.11, 100.1.1, 100.0.12, 100.1.2, 100.1.3, 100.0.13, 100.1.4, 100.0.14, 100.1.5, 100.0.15, 100.1.6, 100.1.7, 100.0.16, 100.0.17, 100.1.8, 100.2.0-rc20].```