### PR TITLE
Update MySQLLockService.php

### DIFF
--- a/Model/MySQLLockService.php
+++ b/Model/MySQLLockService.php
@@ -30,7 +30,11 @@ class MySQLLockService extends AbstractLockService
 
     private function prepareLockName(string $lockName) : string
     {
-        return $this->connection->quote("{$this->getCurrentDatabase()}.$lockName");
+        $lockName = "{$this->getCurrentDatabase()}.$lockName";
+        if (strlen($lockName) >= 64) {
+            $lockName = hash('sha256', $lockName);
+        }
+        return $this->connection->quote($lockName);
     }
 
     private function getCurrentDatabase()


### PR DESCRIPTION
>MySQL 5.7 and later enforces a maximum length on lock names of 64 characters. Previously, no limit was enforced.

https://dev.mysql.com/doc/refman/5.7/en/locking-functions.html#function_get-lock

Long lock names cause the request to fail entirely, detect and fall back to a repeatable string which should suffice for the lock. The error looked like `Incorrect user-level lock name`

If we have a lockname which is too long hash it with sha256 which generates a 64 character string
                                                                                                              
This will ensure our lock still has a consistent name and reference between requests, as well as ensuring this logic works on newer mysql